### PR TITLE
Fix #8 permissions for season_view and episode_view

### DIFF
--- a/enchiridionapi/views/episode_view.py
+++ b/enchiridionapi/views/episode_view.py
@@ -1,6 +1,7 @@
 from rest_framework.decorators import action
 from rest_framework.viewsets import ViewSet
 from rest_framework.response import Response
+from rest_framework.permissions import AllowAny
 from rest_framework import status
 from enchiridionapi.serializers import EpisodeSerializer, LocalEpisodeSerializer
 from enchiridionapi.models import Episode
@@ -9,6 +10,8 @@ import requests, os
 TMDB_API_KEY = os.environ.get('TMDB_API_KEY')
 
 class EpisodeView(ViewSet):
+    permission_classes = [AllowAny]
+
     def list(self, request):
         """
         Gets a list of episodes from the local database
@@ -31,13 +34,6 @@ class EpisodeView(ViewSet):
             return Response(serializer.data, status=status.HTTP_200_OK)
         except Episode.DoesNotExist:
             return Response({"error": "Episode not found"}, status=status.HTTP_404_NOT_FOUND)
-
-    def create(self, request):
-        serializer = LocalEpisodeSerializer(data=request.data)
-        if serializer.is_valid():
-            serializer.save()
-            return Response(serializer.data, status=status.HTTP_201_CREATED)
-        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
     @action(detail=False, methods=['get'])
     def tmdb_episodes(self, request, season_number=None):

--- a/enchiridionapi/views/season_view.py
+++ b/enchiridionapi/views/season_view.py
@@ -1,12 +1,15 @@
 import requests, os
 from rest_framework.viewsets import ViewSet
 from rest_framework.response import Response
+from rest_framework.permissions import AllowAny
 from rest_framework import status
 from enchiridionapi.serializers import SeasonSerializer, SimpleSeasonSerializer
 
 TMDB_API_KEY = os.environ.get('TMDB_API_KEY')
 
 class SeasonView(ViewSet):
+    permission_classes = [AllowAny]
+
     def list(self, request):
         """
         Gets a list of seasons from the TMDB API


### PR DESCRIPTION
# Fix seasons and episodes rendering based on being logged in or not

Allows visitors or registered users to view all seasons, a single season, a list of episodes by season or playlist, or a single episode from a season or playlist whether they're logged in or not

<!-- Add in the issue number here-->
Fixes #8 permissions for season_view and episode_view

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How to Test?

Make sure you've followed all installation and setup instructions in the README

```
git fetch origin nm-permissions-stuff
git checkout nm-permissions-stuff
python manage.py runserver
```

- [ ] Open Postman and send a GET request to `http://localhost:8000/seasons`, be sure to remove any Authorization header if present
- [ ] Do the same for `/seasons/1`, `episodes`, `/episodes/537624`, `/episodes/tmdb/2`, and `/episodes/tmdb/2/1`
- [ ] All should return 200 response codes

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
