### PR TITLE
Nm fixing playlist update

### DIFF
--- a/enchiridionapi/serializers/playlist_serializer.py
+++ b/enchiridionapi/serializers/playlist_serializer.py
@@ -1,9 +1,19 @@
 from rest_framework import serializers
-from enchiridionapi.models import Playlist
+from enchiridionapi.models import Playlist, PlaylistEpisode
+from enchiridionapi.serializers import LocalEpisodeSerializer
 
 class PlaylistSerializer(serializers.ModelSerializer):
+    episodes = serializers.SerializerMethodField()
 
     class Meta:
         model = Playlist
-        fields = ('id', 'user_id', 'name', 'description', 'episodes')
-        depth = 1
+        fields = ['id', 'user_id', 'name', 'description', 'episodes']
+
+    def get_episodes(self, obj):
+        episodes = PlaylistEpisode.objects.filter(playlist=obj).order_by('order_number')
+        episode_list = []
+        for ep in episodes:
+            episode_dict = LocalEpisodeSerializer(ep.episode).data
+            episode_dict['order_number'] = ep.order_number
+            episode_list.append(episode_dict)
+        return episode_list

--- a/enchiridionapi/views/user_playlist_view.py
+++ b/enchiridionapi/views/user_playlist_view.py
@@ -108,6 +108,8 @@ class UserPlaylistView(ViewSet):
                         continue  # if fetching from TMDB API failed, skip this episode
 
                 # Now that we have the episode, add it to the playlist
+                print(f"Episode: {episode}")
+                print(f"Playlist: {playlist}")
                 PlaylistEpisode.objects.create(playlist=playlist, episode=episode, order_number=order_number)
 
             playlist.save()

--- a/enchiridionapi/views/user_playlist_view.py
+++ b/enchiridionapi/views/user_playlist_view.py
@@ -108,8 +108,6 @@ class UserPlaylistView(ViewSet):
                         continue  # if fetching from TMDB API failed, skip this episode
 
                 # Now that we have the episode, add it to the playlist
-                print(f"Episode: {episode}")
-                print(f"Playlist: {playlist}")
                 PlaylistEpisode.objects.create(playlist=playlist, episode=episode, order_number=order_number)
 
             playlist.save()


### PR DESCRIPTION
# Fix order_number not present in each episode of playlists' episodes

There were issues with the client not sending episodes with their order_number back to the server when updating, but it's because they weren't ever sent in the first place
Adds the get_episodes function to `playlist_serializer`

<!-- Add in the issue number here-->
Fixes #11 Fix playlists to return order_number on their list of episodes when perfoming a 'GET' request

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How to Test?

Make sure you've followed all installation and setup instructions in the README

```
git fetch origin nm-fixing-playlist-update
git checkout nm-fixing-playlist-update
python manage.py runserver
```

- [ ] Open Postman and send a `GET` request to `http://localhost:8000/playlists/1`
- [ ] Each episode in the playlist should have an `order_number` field

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes