### PR TITLE
Add #18 Feature: Allow users to search for tv shows

### DIFF
--- a/enchiridion/urls.py
+++ b/enchiridion/urls.py
@@ -24,6 +24,7 @@ router.register(r'episodes', views.EpisodeView, 'episode')
 router.register(r'seasons', views.SeasonView, 'season')
 router.register(r'user-playlists', views.UserPlaylistView, 'user-playlist')
 router.register(r'playlists', views.PublicPlaylistView, 'playlist')
+router.register(r'series', views.SeriesView, 'series')
 
 urlpatterns = [
     path('', include(router.urls)),

--- a/enchiridionapi/serializers/series_serializer.py
+++ b/enchiridionapi/serializers/series_serializer.py
@@ -7,4 +7,4 @@ class SeriesSerializer(serializers.Serializer):
     poster_path = serializers.CharField(allow_blank=True, required=False)
     name = serializers.CharField()
     overview = serializers.CharField(allow_blank=True, required=False)
-    seasons = SimpleSeasonSerializer(many=True)
+    seasons = SimpleSeasonSerializer(many=True, required=False)

--- a/enchiridionapi/views/__init__.py
+++ b/enchiridionapi/views/__init__.py
@@ -3,3 +3,4 @@ from .episode_view import EpisodeView
 from .season_view import SeasonView
 from .user_playlist_view import UserPlaylistView
 from .public_playlist_view import PublicPlaylistView
+from .series_view import SeriesView

--- a/enchiridionapi/views/series_view.py
+++ b/enchiridionapi/views/series_view.py
@@ -1,0 +1,70 @@
+import requests, os
+from rest_framework.viewsets import ViewSet
+from rest_framework.response import Response
+from rest_framework import status
+from enchiridionapi.serializers import SeriesSerializer
+
+TMDB_API_KEY = os.environ.get('TMDB_API_KEY')
+
+class SeriesView(ViewSet):
+    """Series ViewSet
+
+    Args:
+        ViewSet: Inherits from the ViewSet class in the rest_framework package
+    """
+
+    def list (self, request):
+        """GET a list of series from the TMDB API that match the search parameter
+
+        Args:
+            request (dict): the request object from the client
+
+        Returns:
+            a JSON serialized list of series from the TMDB API
+        """
+        search_parameter = request.query_params.get('q')
+
+        if search_parameter is None:
+            return Response({"message": "Please enter a search parameter."}, status=status.HTTP_400_BAD_REQUEST)
+
+        url = f'https://api.themoviedb.org/3/search/tv?query={search_parameter}'
+
+        headers = {
+            "accept": "application/json",
+            "Authorization": f"Bearer {TMDB_API_KEY}"
+        }
+
+        tmdb_response = requests.get(url, headers=headers)
+
+        if tmdb_response.status_code == status.HTTP_200_OK:
+            json_tmdb_response = tmdb_response.json()
+            serializer = SeriesSerializer(json_tmdb_response['results'], many=True)
+            return Response(serializer.data, status=status.HTTP_200_OK)
+        else:
+            return Response({"error": "Unable to fetch data from TMDB API"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+    def retrieve(self, request, pk):
+        """GET a specific series from the TMDB API
+
+        Args:
+            request (dict): the request object from the client
+            pk (int): the primary key of the series
+
+        Returns:
+            a JSON serialized series from the TMDB API
+        """
+        url = f'https://api.themoviedb.org/3/tv/{pk}'
+
+        headers = {
+            "accept": "application/json",
+            "Authorization": f"Bearer {TMDB_API_KEY}"
+        }
+
+        tmdb_response = requests.get(url, headers=headers)
+
+        if tmdb_response.status_code == status.HTTP_200_OK:
+            json_tmdb_response = tmdb_response.json()
+            serializer = SeriesSerializer(json_tmdb_response)
+            return Response(serializer.data, status=status.HTTP_200_OK)
+        else:
+            return Response({"error": "Unable to fetch data from TMDB API"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)


### PR DESCRIPTION
# Allow users to search for tv shows

- Adds `series` endpoint to `enchiridion/urls.py`
- Removes the seasons field requirement in the series serializer in `enchiridionapi/serializers/series_serializer.py`
- Adds the `series_view.py` module and imports it in `__init__.py`

<!-- Add in the issue number here-->
Fixes #18 Adds Feature: Allow users to search for tv shows

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How to Test?

Make sure you've followed all installation and setup instructions in the README

```
git fetch origin nm-searching-shows
git checkout nm-searching-shows
python manage.py runserver
```

- [ ] Open Postman and send a `GET` request to `http://localhost:8000/series?q=Adventure+Time`
- [ ] You should get a list of shows relating to Adventure Time
- [ ] Send another `GET` request to `http://localhost:8000/series/15260`
- [ ] You should get the Adventure Time show object, with seasons this time

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes