### PR TITLE
Fix #26 and simplify local episode creation and reduce search results

### DIFF
--- a/enchiridionapi/views/series_view.py
+++ b/enchiridionapi/views/series_view.py
@@ -29,7 +29,7 @@ class SeriesView(ViewSet):
         if search_parameter is None:
             return Response({"message": "Please enter a search parameter."}, status=status.HTTP_400_BAD_REQUEST)
 
-        url = f'https://api.themoviedb.org/3/search/tv?query={search_parameter}'
+        url = f'https://api.themoviedb.org/3/search/tv?query={search_parameter}&language=en-US&page=1'
 
         headers = {
             "accept": "application/json",


### PR DESCRIPTION
# Minor fix to user-playlist-view.py and series_view.py

- Limited the amount of search results returned by setting language to english and pages to 1 per TMDB documentation
- The client at this point should be sending episodes that are retrieved from TMDB with all of the correct data, so there's no need to fetch them again if they don't already exist in the local database. From `user-playlist-view.py`'s create and update functions, removed unnecessary fetching and serialized the episode after storing the original TMDB episode id as `tmdb_id` field.

### Bug fixes:
<!-- Add in the issue number here-->
Fixes #26 Bug: Editing and creating playlists aren't saving episodes

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How to Test?

Make sure you've followed all installation and setup instructions in the README.

```
git fetch origin nm-searching-shows
git checkout nm-searching-shows
python manage.py runserver
```

- [ ] Open Postman
- [ ] For all following requests sent, make sure that you have set a `Authorization: Token <token>` header. Obtain the token from `authtoken_token` table.
- [ ] Send a `POST` request to `http://localhost:8000/user-playlists` with the body:
```
{
    "name": "Test Playlist 1",
    "description": "This is a test",
    "episodes": [
        {
            "id": 537669,
            "series_id": 15260,
            "series_name": "Adventure Time",
            "name": "It Came from the Nightosphere",
            "air_date": "2010-10-11",
            "season_number": 2,
            "episode_number": 1,
            "overview": "Marceline's evil father goes on a soul-sucking rampage after Finn and Marceline accidentally release him from the Nightosphere.",
            "runtime": 11,
            "still_path": "/jZ1viUzoC02jmHUv7FanhU0niyW.jpg",
            "order_number": 1
        }
    ]
}
```
- [ ] Note the `id` of the response's body
- [ ] Send a `PUT` request to `http://localhost:8000/user-playlists/<id>` with the body:
```
{
    "name": "Test Playlist 1 Edited",
    "description": "This description has been edited",
    "episodes": [
        {
            "air_date": "2010-10-18",
            "episode_number": 2,
            "id": 537651,
            "name": "The Eyes",
            "overview": "Finn and Jake try to rid themselves of a weird horse that creeps them out.",
            "runtime": 11,
            "season_number": 2,
            "series_id": 15260,
            "series_name": "Adventure Time",
            "still_path": "/2KLplGQaB9pg4TMM0ZcckwL45zh.jpg",
            "order_number": 1
        }
    ]
}
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
