### PR TITLE
cookie based authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,27 @@
 # The Enchiridion Server
+
 This repository is part of The Enchiridion project, a web application built to assist users in curating and managing custom playlists for TV series episodes using data from The Movie Database (TMDB). The Enchiridion Server is a RESTful API built with Django and Django Rest Framework.
 
 ## Features
-- Token-based authentication for users
+
+- **Cookie-based authentication for users**
+- Token-based authentication for users (Deprecated)
 - Endpoints to create, read, update, and delete playlists
 - Endpoints to fetch TV series episodes from TMDB
 - Endpoints to store and retrieve episodes from local database
 
 ## Getting Started
+
 These instructions will get you a copy of the project up and running on your local machine for development and testing purposes.
 
 ### Prerequisites
+
 - Python 3.6+
 - Django 4.2+
 - Django Rest Framework 3.13.0+
 
 ### Installation and Setup
+
 1. Clone this repository:
 ```
 git clone git@github.com:macleann/enchiridion-server.git
@@ -45,10 +51,13 @@ python manage.py runserver
 ```
 
 ## Technology Stack
+
 - Django
 - Django REST Framework
 - SQLite
 - TMDB API
+- **Cookie-based Authentication**
 
 ## Contact
+
 Neil MacLean - nbmac13@gmail.com

--- a/enchiridion/authentication.py
+++ b/enchiridion/authentication.py
@@ -1,0 +1,22 @@
+from rest_framework import authentication, exceptions
+from django.contrib.auth.models import User
+from rest_framework_simplejwt.tokens import UntypedToken, TokenError
+from rest_framework_simplejwt.exceptions import InvalidToken
+
+class CookieJWTAuthentication(authentication.BaseAuthentication):
+    def authenticate(self, request):
+        raw_token = request.COOKIES.get('access_token')
+        if not raw_token:
+            return None
+
+        try:
+            UntypedToken(raw_token)
+        except (InvalidToken, TokenError) as e:
+            raise exceptions.AuthenticationFailed(str(e))
+
+        try:
+            user = User.objects.get(id=UntypedToken(raw_token).payload['user_id'])
+        except User.DoesNotExist:
+            raise exceptions.AuthenticationFailed('No such user')
+
+        return (user, None)

--- a/enchiridion/settings.py
+++ b/enchiridion/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/4.2/ref/settings/
 
 from pathlib import Path
 import os
+from datetime import timedelta
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -40,24 +41,86 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'rest_framework',
-    'rest_framework.authtoken',
+    'rest_framework_simplejwt',
     'corsheaders',
     'enchiridionapi',
 ]
 
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (
-        'rest_framework.authentication.TokenAuthentication',
+        'enchiridion.authentication.CookieJWTAuthentication',
     ),
     'DEFAULT_PERMISSION_CLASSES': [
         'rest_framework.permissions.IsAuthenticated',
     ],
 }
 
+CSRF_COOKIE_SAMESITE = 'Lax'
+SESSION_COOKIE_SAMESITE = 'Lax'
+CSRF_COOKIE_HTTPONLY = True
+SESSION_COOKIE_HTTPONLY = True
+CSRF_TRUSTED_ORIGINS = ['http://localhost:3000']
+
+# PROD ONLY
+# CSRF_COOKIE_SECURE = True
+# SESSION_COOKIE_SECURE = True
+
 CORS_ORIGIN_WHITELIST = (
     'http://localhost:3000',
     'http://127.0.0.1:3000'
 )
+CORS_EXPOSE_HEADERS = ['Content-Type', 'X-CSRFToken']
+CORS_ALLOW_CREDENTIALS = True
+
+SIMPLE_JWT = {
+    "ACCESS_TOKEN_LIFETIME": timedelta(days=1),
+    "REFRESH_TOKEN_LIFETIME": timedelta(days=60),
+    "ROTATE_REFRESH_TOKENS": False,
+    "BLACKLIST_AFTER_ROTATION": False,
+    "UPDATE_LAST_LOGIN": True,
+
+    "ALGORITHM": "HS256",
+    "SIGNING_KEY": SECRET_KEY,
+    "VERIFYING_KEY": "",
+    "AUDIENCE": None,
+    "ISSUER": None,
+    "JSON_ENCODER": None,
+    "JWK_URL": None,
+    "LEEWAY": 0,
+
+    "AUTH_HEADER_TYPES": ("Bearer",),
+    "AUTH_HEADER_NAME": "HTTP_AUTHORIZATION",
+    "USER_ID_FIELD": "id",
+    "USER_ID_CLAIM": "user_id",
+    "USER_AUTHENTICATION_RULE": "rest_framework_simplejwt.authentication.default_user_authentication_rule",
+
+    "AUTH_TOKEN_CLASSES": ("rest_framework_simplejwt.tokens.AccessToken",),
+    "TOKEN_TYPE_CLAIM": "token_type",
+    "TOKEN_USER_CLASS": "rest_framework_simplejwt.models.TokenUser",
+
+    "JTI_CLAIM": "jti",
+
+    "SLIDING_TOKEN_REFRESH_EXP_CLAIM": "refresh_exp",
+    "SLIDING_TOKEN_LIFETIME": timedelta(minutes=5),
+    "SLIDING_TOKEN_REFRESH_LIFETIME": timedelta(days=1),
+
+    "TOKEN_OBTAIN_SERIALIZER": "rest_framework_simplejwt.serializers.TokenObtainPairSerializer",
+    "TOKEN_REFRESH_SERIALIZER": "rest_framework_simplejwt.serializers.TokenRefreshSerializer",
+    "TOKEN_VERIFY_SERIALIZER": "rest_framework_simplejwt.serializers.TokenVerifySerializer",
+    "TOKEN_BLACKLIST_SERIALIZER": "rest_framework_simplejwt.serializers.TokenBlacklistSerializer",
+    "SLIDING_TOKEN_OBTAIN_SERIALIZER": "rest_framework_simplejwt.serializers.TokenObtainSlidingSerializer",
+    "SLIDING_TOKEN_REFRESH_SERIALIZER": "rest_framework_simplejwt.serializers.TokenRefreshSlidingSerializer",
+    
+    # Custom settings!
+    "AUTH_COOKIE": 'access_token',
+    "AUTH_COOKIE_REFRESH": 'refresh_token',
+    "AUTH_COOKIE_DOMAIN": None,
+    "AUTH_COOKIE_SECURE": True, # Change to True in production
+    "AUTH_COOKIE_SAMESITE": 'Lax', # Change to 'Lax' in production
+    "AUTH_COOKIE_HTTPONLY": True,
+    "AUTH_COOKIE_PATH": "/",
+    
+}
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',

--- a/enchiridion/urls.py
+++ b/enchiridion/urls.py
@@ -31,5 +31,7 @@ urlpatterns = [
     path('register', views.register_user),
     path('login', views.login_user),
     path('google/login', views.google_login),
+    path('verify', views.verify_token),
+    path('logout', views.logout_user),
     path('admin/', admin.site.urls),
 ]

--- a/enchiridionapi/views/__init__.py
+++ b/enchiridionapi/views/__init__.py
@@ -1,4 +1,4 @@
-from .auth import login_user, register_user, google_login
+from .auth import verify_token, login_user, register_user, google_login, logout_user
 from .episode_view import EpisodeView
 from .season_view import SeasonView
 from .user_playlist_view import UserPlaylistView


### PR DESCRIPTION
# Cookie based auth and Global state via Redux

Jeezo peezo, my got, this was... phew... rough. Implemented SimpleJWT and followed the documentation pretty closely. Had a really rough time getting authentication to work. I feel like session based authentication should have worked with some tweaks, but I admit, I'm in a tad bit over my head (lookin' at you CSRF tokens). Anyhoo...

- CUSTOM AUTHENTICATION CLASS. The only way I could get it to use the user's cookies in the client to authenticate any request they're making that isn't set to the AllowAny permission
- I got some cleaning up to do, but set some settings via SimpleJWT's documentation in settings.py
- Implemented verify_user and logout functions in `views/auth.py`
- More cleaning up to do in `views/auth.py` such as implementing a class for both refresh tokens and generating cookies to make code more DRY, but I was having some issues with it upon first try so I decided to get it working first

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How to Test?

Make sure you've followed all installation and setup instructions in the README. Requires the most recent client code to test.

```
git fetch origin nm-cookies-jwt
git checkout nm-cookies-jwt
python manage.py runserver
```

- [ ] Log in or create an account (either with google or a native account)
- [ ] Peek them cookies in Application/Cookies with your dev tools (should be refresh_token and access_token)
- [ ] Make a playlist, edit, whatever you want
- [ ] Log out
- [ ] Notice them cookies be gone

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes