### PR TITLE
new like functionality and cookie improvements

### DIFF
--- a/enchiridion/authentication.py
+++ b/enchiridion/authentication.py
@@ -5,7 +5,7 @@ from rest_framework_simplejwt.exceptions import InvalidToken
 
 class CookieJWTAuthentication(authentication.BaseAuthentication):
     def authenticate(self, request):
-        raw_token = request.COOKIES.get('access_token')
+        raw_token = request.COOKIES.get('refresh_token')
         if not raw_token:
             return None
 

--- a/enchiridionapi/serializers/playlist_serializer.py
+++ b/enchiridionapi/serializers/playlist_serializer.py
@@ -6,15 +6,22 @@ from enchiridionapi.serializers import LocalEpisodeSerializer
 class PlaylistSerializer(serializers.ModelSerializer):
     episodes = serializers.SerializerMethodField()
     likes_count = serializers.IntegerField(read_only=True)
+    is_liked = serializers.SerializerMethodField()
 
     class Meta:
         model = Playlist
-        fields = ['id', 'user_id', 'name', 'description', 'episodes', 'likes_count']
+        fields = ['id', 'user_id', 'name', 'description', 'episodes', 'likes_count', 'is_liked']
 
     def get_episodes(self, obj):
         episode_playlist = obj.playlist_episodes
         serializer = LocalEpisodeSerializer([ep.episode for ep in episode_playlist], many=True)
         return serializer.data
+    
+    def get_is_liked(self, obj):
+        user = self.context['request'].user
+        if user.is_authenticated:
+            return obj.like_set.filter(user=user).exists()
+        return False
 
     @staticmethod
     def setup_eager_loading(queryset):

--- a/enchiridionapi/views/public_playlist_view.py
+++ b/enchiridionapi/views/public_playlist_view.py
@@ -20,17 +20,17 @@ class PublicPlaylistView(ViewSet):
             days_to_int = int(request.query_params.get('days'))
             trending_time = timezone.now() - timedelta(days=days_to_int)
 
-            trending_playlists = (
+            trending_playlists = PlaylistSerializer.setup_eager_loading(
                 Playlist.objects
                 .filter(like__date_liked__gte=trending_time)
-                .annotate(like_count=Count('like'))
-                .order_by('-like_count')
+                .annotate(likes_count=Count('like'))
+                .order_by('-likes_count')
             )
-            serializer = PlaylistSerializer(trending_playlists, many=True)
+            serializer = PlaylistSerializer(trending_playlists, many=True, context={'request': request})
             return Response(serializer.data, status=status.HTTP_200_OK)
         
         playlists = PlaylistSerializer.setup_eager_loading(Playlist.objects.annotate(likes_count=Count('like')))
-        serializer = PlaylistSerializer(playlists, many=True)
+        serializer = PlaylistSerializer(playlists, many=True, context={'request': request})
         return Response(serializer.data, status=status.HTTP_200_OK)
 
     def retrieve(self, request, pk=None):


### PR DESCRIPTION
# Updated relevant `like`-related fields for playlists, Fixed cookies

- Added a `is_liked` method field to `playlist_serializer.py` to check for an authenticated user and if so, a matching `like` object from the user resulting in the True boolean value
- This meant I had to pass context in `public_playlist_view.py` for the serializer to be able to find the user

A deeper dive into the users and I found that I needed to make some changes in regards to authentication, cookies, and the like. Ultimately, I edited it a lot and maybe there are some questionable decisions there, but it's working for me.

- Changed the token checked for to `refresh_token` in the Authentication method settings
- Changed how the whole `/verify` endpoint works in `auth.py` view
- Cookies are set in a consistent manner across `auth.py` view

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How to Test?

Make sure you've followed all installation and setup instructions in the README.

```
git fetch origin nm-likes
git checkout nm-likes
python manage.py runserver
```

- [ ] checkout the most recent version of the [client side](https://github.com/macleann/enchiridion-client)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes