### PR TITLE
Seeing if /v2/ registry endpoint helps

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
             steps {
                 script {
                     // Login to DockerHub and build the image with the linux/amd64 platform flag because this is building on my ARM64 machine
-                    withDockerRegistry([ credentialsId: "docker-hub-creds", url: "" ]) {
+                    withDockerRegistry([ credentialsId: "docker-hub-creds", url: "https://index.docker.io/v2/" ]) {
                         def app = docker.build("macleann/enchiridion-server", "--platform linux/amd64 .")
 
                         // Tagging with build number and 'latest'


### PR DESCRIPTION
Something is going wrong with Jenkins despite me not having done anything to Jenkins config. Not too sure what the issue is. First it couldn't recognize the use of any `docker` commands, but now, it's mad about `desktop-linux` context. I honestly don't think that this'll solve it, but I'd love to be happily surprised.