### PR TITLE
fixing serializer bug

### DIFF
--- a/enchiridionapi/serializers/playlist_serializer.py
+++ b/enchiridionapi/serializers/playlist_serializer.py
@@ -13,9 +13,11 @@ class PlaylistSerializer(serializers.ModelSerializer):
         fields = ['id', 'user_id', 'name', 'description', 'episodes', 'likes_count', 'is_liked']
 
     def get_episodes(self, obj):
-        episode_playlist = obj.playlistepisode_set.all()
-        serializer = LocalEpisodeSerializer([ep.episode for ep in episode_playlist], many=True)
-        return serializer.data
+        if hasattr(obj, 'playlist_episodes'):
+            return [{'order_number': ep.order_number, **LocalEpisodeSerializer(ep.episode).data} for ep in obj.playlist_episodes]
+        else:
+            episodes = PlaylistEpisode.objects.filter(playlist=obj).order_by('order_number')
+            return [{'order_number': ep.order_number, **LocalEpisodeSerializer(ep.episode).data} for ep in episodes]
     
     def get_is_liked(self, obj):
         user = self.context['request'].user

--- a/enchiridionapi/views/public_playlist_view.py
+++ b/enchiridionapi/views/public_playlist_view.py
@@ -36,7 +36,9 @@ class PublicPlaylistView(ViewSet):
     def retrieve(self, request, pk=None):
         """Handles GET requests for single playlist"""
         try:
-            playlist = PlaylistSerializer.setup_eager_loading(Playlist.objects.filter(pk=pk)).get()
+            queryset = Playlist.objects.filter(pk=pk)
+            queryset = PlaylistSerializer.setup_eager_loading(queryset)
+            playlist = queryset.get()
             serializer = PlaylistSerializer(playlist, context={'request': request})
             return Response(serializer.data)
         except Playlist.DoesNotExist:


### PR DESCRIPTION
# Playlist serializer now properly appending `order_number` to playlists

I encountered an issue when attempting to update a playlist, specifically when adding new episodes, that causes it to remove all episodes and save the playlist. That's obviously not good, so I had to jump in to see if it was happening in the client side or server side. I was able to reproduce the bug locally, which was great news.

The problem was with the `get_episodes` function of my `playlist_serializer` serializer. Previously (a long time ago), I had been appending the `order_number` in this function like so:
```
    def get_episodes(self, obj):
        episodes = PlaylistEpisode.objects.filter(playlist=obj).order_by('order_number')
        episode_list = []
        for ep in episodes:
            episode_dict = LocalEpisodeSerializer(ep.episode).data
            episode_dict['order_number'] = ep.order_number
            episode_list.append(episode_dict)
        return episode_list
```

This worked, and still would, except that I had had trouble with a prior version of deployment around December where there were **HUGE** issues with database latency (there may be a more technical, commonplace term for this). My queries were lasting up to 15 seconds. I looked into this and ran across the "N+1 query problem" and attempted to solve this with eager loading via prefetching. I'd be lying if I said I didn't use AI tools to help me solve this problem, but I made sure to have a decent enough understanding before implementing it. Spoiler alert: It didn't solve my latency issue, and I decided to completely reconfigure my deployment approach that ended up saving me money!

However, this change at some point broke the way `playlist_episodes` were fetched and in turn the appendation of the needed `order_number` field on the serialized episode dictionaries within the parent serialized playlist dictionary. I say "at some point" because I recall testing CRUD functionality before pushing into my `main` branch. At any rate, the notable changes are as follows:
```
    def get_episodes(self, obj):
        if hasattr(obj, 'playlist_episodes'):
            return [{'order_number': ep.order_number, **LocalEpisodeSerializer(ep.episode).data} for ep in obj.playlist_episodes]
        else:
            episodes = PlaylistEpisode.objects.filter(playlist=obj).order_by('order_number')
            return [{'order_number': ep.order_number, **LocalEpisodeSerializer(ep.episode).data} for ep in episodes]
```

Now, if you're like me, the return statements are a total mindf***, but I discovered what's happening is very cool. I did attempt to solve this issue myself, but my answer seemed clunky and unintuitive. For the purposes of documentation, I will provide the explanation below:

1. Condition using `hasattr`:

-   `hasattr(obj, 'playlist_episodes')`: This checks if the `obj` (which is a `Playlist` instance) has the attribute `playlist_episodes`. This attribute is added dynamically when prefetching related data.

2. Return Statement with Ternary Operator:

-   If `obj` has the attribute `playlist_episodes`, it means that the related episodes were prefetched. In this case:
      -   `[{'order_number': ep.order_number, **LocalEpisodeSerializer(ep.episode).data} for ep in obj.playlist_episodes]`: This is a list comprehension iterating over each `PlaylistEpisode` object in `obj.playlist_episodes`. For each episode (`ep`), it constructs a dictionary with the `order_number` attribute of the episode and the serialized data of the episode obtained using `LocalEpisodeSerializer`.
-   If `obj` doesn't have the attribute `playlist_episodes`, it means that the related episodes were not prefetched. In this case:
      -   `episodes = PlaylistEpisode.objects.filter(playlist=obj).order_by('order_number')`: This retrieves all `PlaylistEpisode` objects related to the given `Playlist` object (`obj`) from the database and orders them by the `order_number`.
      -   `[{'order_number': ep.order_number, **LocalEpisodeSerializer(ep.episode).data} for ep in episodes]`: Similar to the previous case, it constructs a list of dictionaries with the `order_number` attribute and the serialized data of each episode.

3. Shorthand Notation (`**LocalEpisodeSerializer(ep.episode).data`):

- `LocalEpisodeSerializer(ep.episode).data`: This part serializes the `Episode` object associated with each `PlaylistEpisode` object using the `LocalEpisodeSerializer` and retrieves its serialized representation.
- `**` is the unpacking operator in Python. It unpacks the serialized data (which is a dictionary) into the outer dictionary being constructed in the list comprehension.
- So, `{**LocalEpisodeSerializer(ep.episode).data}` merges the serialized data dictionary into the outer dictionary being constructed in the list comprehension.

Next, there are changes to `public_playlist_view`'s retrieve function that resulted in the following:

```
    def retrieve(self, request, pk=None):
        """Handles GET requests for single playlist"""
        try:
            queryset = Playlist.objects.filter(pk=pk) # Call the db to build the queryset before fetching data
            queryset = PlaylistSerializer.setup_eager_loading(queryset) # Modify the queryset to prefetch related data
            playlist = queryset.get() # Fetch the data from the db with the modified queryset
            serializer = PlaylistSerializer(playlist, context={'request': request}) # Serialize the data
            return Response(serializer.data) # Respond to the client with the serialized data
        except Playlist.DoesNotExist:
            return Response({'message': 'Playlist does not exist.'}, status=status.HTTP_404_NOT_FOUND)
```

I feel like a better developer for identifying the issue and debugging it with the best tools at my disposal. I would never have come up with a solution so elegant!

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How to Test?

Make sure you've followed all installation and setup instructions in the README.

```
git fetch origin nm-serializers
git checkout nm-serializers
python manage.py runserver
```

- [ ] Spin up the client locally
- [ ] Authenticate
- [ ] Add an episode to an existing playlist
- [ ] I really don't feel like adding Postman instructions here, though I suppose you could look at prior PR's where I do go into depth on how to update a playlist and add an episode that way. It's just way easier to do so with the most up-to-date client side.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes