### PR TITLE
Modifying Jenkinsfile for more secure Docker Hub login 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,6 +8,11 @@ pipeline {
         stage('Build and Push Image') {
             steps {
                 script {
+                    // Login to DockerHub
+                    withCredentials([usernamePassword(credentialsId: 'docker-hub-creds', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
+                        sh 'sudo docker login -u $USERNAME -p $PASSWORD'
+                    }
+
                     // Build the image with the linux/amd64 platform flag
                     def app = docker.build("macleann/enchiridion-server", "--platform linux/amd64 .")
 
@@ -19,14 +24,8 @@ pipeline {
                     app.tag(latestTag)
 
                     // Push both tags to DockerHub
-                    withCredentials([usernamePassword(credentialsId: 'docker-hub-creds', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
-                        sh '''
-                            echo "${PASSWORD} | docker login -u ${USERNAME} --password-stdin"
-                         '''
-                        app.push(versionTag)
-                        app.push(latestTag)
-                    }
-                    
+                    app.push(versionTag)
+                    app.push(latestTag)
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,13 +8,6 @@ pipeline {
         stage('Build and Push Image') {
             steps {
                 script {
-                    // Login to DockerHub
-                    withCredentials([usernamePassword(credentialsId: 'docker-hub-creds', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
-                        sh '''
-                            echo "${PASSWORD} | docker login -u ${USERNAME} --password-stdin"
-                         '''
-                    }
-
                     // Build the image with the linux/amd64 platform flag
                     def app = docker.build("macleann/enchiridion-server", "--platform linux/amd64 .")
 
@@ -26,8 +19,14 @@ pipeline {
                     app.tag(latestTag)
 
                     // Push both tags to DockerHub
-                    app.push(versionTag)
-                    app.push(latestTag)
+                    withCredentials([usernamePassword(credentialsId: 'docker-hub-creds', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
+                        sh '''
+                            echo "${PASSWORD} | docker login -u ${USERNAME} --password-stdin"
+                         '''
+                        app.push(versionTag)
+                        app.push(latestTag)
+                    }
+                    
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,9 +9,7 @@ pipeline {
             steps {
                 script {
                     // Login to DockerHub
-                    withCredentials([usernamePassword(credentialsId: 'docker-hub-creds', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
-                        sh 'sudo docker login -u $USERNAME -p $PASSWORD'
-                    }
+                    sh 'docker login'
 
                     // Build the image with the linux/amd64 platform flag
                     def app = docker.build("macleann/enchiridion-server", "--platform linux/amd64 .")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
                 script {
                     // Login to DockerHub
                     withCredentials([usernamePassword(credentialsId: 'docker-hub-creds', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
-                        sh 'docker login -u $USERNAME -p $PASSWORD'
+                        sh 'echo $PASSWORD | docker login -u $USERNAME --password-stdin'
                     }
 
                     // Build the image with the linux/amd64 platform flag

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,9 @@ pipeline {
             steps {
                 script {
                     // Login to DockerHub
-                    sh 'docker login'
+                    withCredentials([usernamePassword(credentialsId: 'docker-hub-creds', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
+                        sh 'docker login -u $USERNAME -p $PASSWORD'
+                    }
 
                     // Build the image with the linux/amd64 platform flag
                     def app = docker.build("macleann/enchiridion-server", "--platform linux/amd64 .")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,9 @@ pipeline {
                 script {
                     // Login to DockerHub
                     withCredentials([usernamePassword(credentialsId: 'docker-hub-creds', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
-                        sh 'docker login -u $USERNAME -p $PASSWORD'
+                        sh '''
+                            echo "${PASSWORD} | docker login -u ${USERNAME} --password-stdin"
+                         '''
                     }
 
                     // Build the image with the linux/amd64 platform flag


### PR DESCRIPTION
I think Docker may have made some changes regarding the ability to login with `-p *******` flag in their CLI. I kept getting:
```
+ docker login -u **** -p ****
WARNING! Using --password via the CLI is insecure. Use --password-stdin.
Error saving credentials: error storing credentials - err: exit status 1, out: `error storing credentials - err: exit status 1, out: `User interaction is not allowed.``
```

This was very confusing as I had made 0 changes to my pipeline when it worked a month ago. C'est la vie...

The ultimate change was hilariously simple. It just took me a while to find the proper documentation to be combing through.